### PR TITLE
try to create recipe for pgenlib

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,8 @@ jobs:
           echo "$matrix"
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
-  build-and-push:
+  build:
+    name: Build on ${{ matrix.os }}
     needs: get_dirs
     runs-on: ${{ matrix.os }}
     permissions:
@@ -98,7 +99,7 @@ jobs:
         run: |
           bioconda-utils build --packages ${{ matrix.packagename }}
 
-      - name: Upload built package
+      - name: Upload built package as GitHub artifact
         uses: "actions/upload-artifact@v4"
         with:
           name: ${{ matrix.packagename }}-${{ matrix.os }}

--- a/recipes/pgenlib/conda_build_config.yaml
+++ b/recipes/pgenlib/conda_build_config.yaml
@@ -1,0 +1,7 @@
+numpy:
+  # part of a zip_keys: python, python_impl, numpy
+  - 1.22
+  - 2.0
+  - 2.0
+  - 2.0
+  - 2.0

--- a/recipes/pgenlib/conda_build_config.yaml
+++ b/recipes/pgenlib/conda_build_config.yaml
@@ -1,7 +1,0 @@
-numpy:
-  # part of a zip_keys: python, python_impl, numpy
-  - 1.22
-  - 2.0
-  - 2.0
-  - 2.0
-  - 2.0

--- a/recipes/pgenlib/meta.yaml
+++ b/recipes/pgenlib/meta.yaml
@@ -22,12 +22,10 @@ requirements:
     - python
     - pip
     - cython
-    - numpy >=2.0 # [py>38]
-    - numpy # [py<39]
+    - numpy
     - zlib
   run:
     - python
-    - {{ pin_compatible('numpy') }}
 
 test:
   imports:

--- a/recipes/pgenlib/meta.yaml
+++ b/recipes/pgenlib/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pip
     - cython 
     - numpy >=2.0.0  # [py >= 39]
-    - numpy >=1.17.3  # [py < 39]
+    - numpy  # [py < 39]
     - zlib
   run:
     - python

--- a/recipes/pgenlib/meta.yaml
+++ b/recipes/pgenlib/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 0
-  skip: True  # [py < 37]
   script: "{{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation"
   run_exports:
     - {{ pin_subpackage('pgenlib', max_pin="x.x") }}
@@ -24,11 +23,10 @@ requirements:
     - pip
     - cython
     - numpy >=2.0.0  # [py >= 39]
-    - numpy >=1.16.0,<2.0.0  # [py < 39]
+    - numpy >=1.19.0,<2.0.0  # [py < 39]
     - zlib
   run:
     - python
-    - {{ pin_compatible('numpy') }}
 
 test:
   imports:

--- a/recipes/pgenlib/meta.yaml
+++ b/recipes/pgenlib/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pip
     - cython 
     - numpy >=2.0.0  # [py >= 39]
-    - numpy 1.17.3  # [py < 39]
+    - numpy >=1.17.3  # [py < 39]
     - zlib
   run:
     - python

--- a/recipes/pgenlib/meta.yaml
+++ b/recipes/pgenlib/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "pgenlib" %}
+{% set version = "0.91.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 09825be43ffb25bc68b6e243b98989a5bc35a8aa22cd749fd9f602d778dd6bd0
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation"
+  run_exports:
+    - {{ pin_subpackage('pgenlib', max_pin="x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+  host:
+    - python
+    - pip
+    - cython
+    - numpy
+    - zlib
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+
+test:
+  imports:
+    - {{ name }}
+
+about:
+  home: "https://github.com/chrchang/plink-ng"
+  license: "LGPL-3.0-or-later"
+  license_family: LGPL
+  license_file: LICENSE
+  summary: "Python wrapper for pgenlib's basic reader and writer."
+  doc_url: "https://github.com/chrchang/plink-ng/blob/master/2.0/Python/README.md"
+  dev_url: "https://github.com/chrchang/plink-ng/tree/master/2.0/Python"
+
+extra:
+  recipe-maintainers:
+    - chrchang
+  identifiers:
+    - doi:10.1186/s13742-015-0047-8

--- a/recipes/pgenlib/meta.yaml
+++ b/recipes/pgenlib/meta.yaml
@@ -21,10 +21,9 @@ requirements:
   host:
     - python
     - pip
-    - cython # [py >= 39]
-    - cython <3.0.0 # [py < 39]    
+    - cython 
     - numpy >=2.0.0  # [py >= 39]
-    - numpy >=1.19.0,<2.0.0  # [py < 39]
+    - numpy 1.17.3  # [py < 39]
     - zlib
   run:
     - python

--- a/recipes/pgenlib/meta.yaml
+++ b/recipes/pgenlib/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: 09825be43ffb25bc68b6e243b98989a5bc35a8aa22cd749fd9f602d778dd6bd0
+  sha256: 32992274214d2e6735b721544abfd0ae0c76906c4193120f7091065b88f68dfa
 
 build:
   number: 0

--- a/recipes/pgenlib/meta.yaml
+++ b/recipes/pgenlib/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - zlib
   run:
     - python
+    - numpy >=1.19.0
 
 test:
   imports:

--- a/recipes/pgenlib/meta.yaml
+++ b/recipes/pgenlib/meta.yaml
@@ -47,3 +47,6 @@ extra:
     - chrchang
   identifiers:
     - doi:10.1186/s13742-015-0047-8
+  additional-platforms:
+    - linux-aarch64
+    - osx-arm64

--- a/recipes/pgenlib/meta.yaml
+++ b/recipes/pgenlib/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pgenlib" %}
-{% set version = "0.90.2" %}
+{% set version = "0.91.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -21,12 +21,13 @@ requirements:
   host:
     - python
     - pip
-    - cython
-    - numpy
+    - cython # [py >= 39]
+    - cython < 3.0.0 # [py < 39]    
+    - numpy >=2.0.0  # [py >= 39]
+    - numpy >=1.26.0,<2.0.0  # [py < 39]
     - zlib
   run:
     - python
-    - {{ pin_compatible('numpy') }}
 
 test:
   imports:

--- a/recipes/pgenlib/meta.yaml
+++ b/recipes/pgenlib/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - zlib
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - {{ pin_compatible('numpy') }} # [py<39]
 
 test:
   imports:

--- a/recipes/pgenlib/meta.yaml
+++ b/recipes/pgenlib/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python
     - pip
     - cython # [py >= 39]
-    - cython < 3.0.0 # [py < 39]    
+    - cython <3.0.0 # [py < 39]    
     - numpy >=2.0.0  # [py >= 39]
     - numpy >=1.26.0,<2.0.0  # [py < 39]
     - zlib

--- a/recipes/pgenlib/meta.yaml
+++ b/recipes/pgenlib/meta.yaml
@@ -22,11 +22,12 @@ requirements:
     - python
     - pip
     - cython
-    - numpy
+    - numpy >=2.0 # [py>38]
+    - numpy # [py<39]
     - zlib
   run:
     - python
-    - {{ pin_compatible('numpy') }} # [py<39]
+    - {{ pin_compatible('numpy') }}
 
 test:
   imports:

--- a/recipes/pgenlib/meta.yaml
+++ b/recipes/pgenlib/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - cython # [py >= 39]
     - cython <3.0.0 # [py < 39]    
     - numpy >=2.0.0  # [py >= 39]
-    - numpy >=1.26.0,<2.0.0  # [py < 39]
+    - numpy >=1.19.0,<2.0.0  # [py < 39]
     - zlib
   run:
     - python

--- a/recipes/pgenlib/meta.yaml
+++ b/recipes/pgenlib/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py < 37]
   script: "{{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation"
   run_exports:
     - {{ pin_subpackage('pgenlib', max_pin="x.x") }}
@@ -22,10 +23,12 @@ requirements:
     - python
     - pip
     - cython
-    - numpy
+    - numpy >=2.0.0  # [py >= 39]
+    - numpy >=1.16.0,<2.0.0  # [py < 39]
     - zlib
   run:
     - python
+    - {{ pin_compatible('numpy') }}
 
 test:
   imports:

--- a/recipes/pgenlib/meta.yaml
+++ b/recipes/pgenlib/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pgenlib" %}
-{% set version = "0.91.0" %}
+{% set version = "0.90.2" %}
 
 package:
   name: "{{ name|lower }}"
@@ -22,11 +22,11 @@ requirements:
     - python
     - pip
     - cython
-    - numpy >=2.0.0  # [py >= 39]
-    - numpy >=1.19.0,<2.0.0  # [py < 39]
+    - numpy
     - zlib
   run:
     - python
+    - {{ pin_compatible('numpy') }}
 
 test:
   imports:


### PR DESCRIPTION
for version v0.91.0 of [pgenlib](https://github.com/chrchang/plink-ng/tree/master/2.0%2FPython) which adds support for numpy 2.0

see https://github.com/chrchang/plink-ng/pull/272

what's weird is that it was able to compile [in the github actions for the pgenlib repo](https://github.com/chrchang/plink-ng/actions/runs/9576994429) but not in the bioconda env, for some reason

things I am trying:
- [ ] using a different compiler? perhaps it isn't using the same one that was used to build the wheels