### PR TITLE
art: ensure dyld library path is set

### DIFF
--- a/recipes/art/build.sh
+++ b/recipes/art/build.sh
@@ -5,6 +5,7 @@ set -xe
 export CFLAGS="-I$PREFIX/include"
 export LDFLAGS="-L$PREFIX/lib"
 export CPATH=${PREFIX}/include
+export DYLD_LIBRARY_PATH="$PREFIX/lib:$DYLD_LIBRARY_PATH"
 
 mkdir -p $PREFIX/bin
 

--- a/recipes/art/meta.yaml
+++ b/recipes/art/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 12
+  number: 13
   run_exports:
     - {{ pin_subpackage(name, max_pin=None) }}
 


### PR DESCRIPTION
tries to fix an issue that has been popping up intermittently in our CI
https://github.com/gymrek-lab/TRTools/actions/runs/10619172232/job/29436136724#step:10:385

> dyld[6218]: Library not loaded: @rpath/libgsl.25.dylib
  Referenced from: <8CA56B29-9796-310F-82ED-4E3BB7AB4C56> /Users/runner/conda_pkgs_dir/art-2016.06.05-h9d19d21_12/bin/art_illumina
  Reason: tried: '/Users/runner/conda_pkgs_dir/art-2016.06.05-h9d19d21_12/bin/../lib/libgsl.25.dylib' (no such file), '/Users/runner/conda_pkgs_dir/art-2016.06.05-h9d19d21_12/bin/../lib/libgsl.25.dylib' (no such file), '/usr/local/lib/libgsl.25.dylib' (no such file), '/usr/lib/libgsl.25.dylib' (no such file, not in dyld cache)